### PR TITLE
[Misc] Fix Python hashbang to force v.2

### DIFF
--- a/create-archive.py
+++ b/create-archive.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import sys,os,subprocess,re
 from time import strftime

--- a/generate-scripts.py
+++ b/generate-scripts.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # Francesco Conti <f.conti@unibo.it>
 #
 # Copyright (C) 2016 ETH Zurich, University of Bologna.

--- a/push-ips.py
+++ b/push-ips.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # Francesco Conti <f.conti@unibo.it>
 #
 # Copyright (C) 2016 ETH Zurich, University of Bologna.

--- a/sw/apps/riscv_tests/testALUExt/gen_stimuli.py
+++ b/sw/apps/riscv_tests/testALUExt/gen_stimuli.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import sys
 import random

--- a/sw/apps/riscv_tests/testBitManipulation/gen_stimuli.py
+++ b/sw/apps/riscv_tests/testBitManipulation/gen_stimuli.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import sys
 import random

--- a/sw/apps/riscv_tests/testCSR/gen_stimuli.py
+++ b/sw/apps/riscv_tests/testCSR/gen_stimuli.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import sys
 import random

--- a/sw/apps/riscv_tests/testShufflePack/gen_stimuli.py
+++ b/sw/apps/riscv_tests/testShufflePack/gen_stimuli.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import sys
 import random

--- a/sw/apps/riscv_tests/testVecArith/gen_stimuli.py
+++ b/sw/apps/riscv_tests/testVecArith/gen_stimuli.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import sys
 import random

--- a/sw/apps/sequential_tests/matrixAdd/gen_stimuli.py
+++ b/sw/apps/sequential_tests/matrixAdd/gen_stimuli.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import sys
 import random

--- a/sw/apps/sequential_tests/matrixMul16/gen_stimuli.py
+++ b/sw/apps/sequential_tests/matrixMul16/gen_stimuli.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import sys
 import random

--- a/sw/apps/sequential_tests/matrixMul32/gen_stimuli.py
+++ b/sw/apps/sequential_tests/matrixMul32/gen_stimuli.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import sys
 import random

--- a/sw/apps/sequential_tests/matrixMul8/gen_stimuli.py
+++ b/sw/apps/sequential_tests/matrixMul8/gen_stimuli.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import sys
 import random

--- a/sw/apps/sequential_tests/matrixMul8_dotp/gen_stimuli.py
+++ b/sw/apps/sequential_tests/matrixMul8_dotp/gen_stimuli.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import sys
 import random

--- a/sw/utils/annotate.py
+++ b/sw/utils/annotate.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import sys
 

--- a/sw/utils/s19toboot.py
+++ b/sw/utils/s19toboot.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 # ////////////////////////////////////////////////////////////////////////////////
 # // Company:        Multitherman Laboratory @ DEIS - University of Bologna     //

--- a/sw/utils/s19toslm.py
+++ b/sw/utils/s19toslm.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 # ////////////////////////////////////////////////////////////////////////////////
 # // Company:        Multitherman Laboratory @ DEIS - University of Bologna     //

--- a/tag-ips.py
+++ b/tag-ips.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # Francesco Conti <f.conti@unibo.it>
 #
 # Copyright (C) 2016 ETH Zurich, University of Bologna.

--- a/update-ips.py
+++ b/update-ips.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # Francesco Conti <f.conti@unibo.it>
 #
 # Copyright (C) 2016 ETH Zurich, University of Bologna.


### PR DESCRIPTION
In systems where Python 3 is the default interpreter, enforcing the hashbang to version 2 is mandatory.
This change should not affect other systems where Python 2 is the only or the default interpreter.