### PR TITLE
README: Use the absolute URL of graphic

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<img src="doc/datasheet/figures/pulpino_logo_inline1.png" width="400px" />
+<img src="https://raw.githubusercontent.com/pulp-platform/pulpino/master/doc/datasheet/figures/pulpino_logo_inline1.png" width="400px" />
 
 # Introduction
 


### PR DESCRIPTION
Hi guys,

we are preparing the demo for the LibreCores.org launch scheduled today at ORCONF. We plan to use Pulpino as the demo project to show the basic project setup flow. For that we stumbled over a minor issue which is not trivial to fix on the LibreCores.org side: The README.md contains a relative URL which is a bit problematic to render generally (because a default git repository doesn't serve files).

It would be great if you merged this commit. The URL I used is the static URL suggested by Github.

Cheers,
Stefan