### PR TITLE
fix: fix pulpinov1 commit issue

### DIFF
--- a/ips_list.yml
+++ b/ips_list.yml
@@ -62,7 +62,7 @@ axi/core2axi:
   commit: pulpinov1
 
 adv_dbg_if:
-  commit: pulpinov1
+  commit: c440ae8 # pulpinov1 branch was deleted, this is the commit where pulpinov1 was merged.
 
 riscv:
   commit: pulpinov1


### PR DESCRIPTION
The old code searches for a branch called `pulpinov1` which no longer exists, so I have added the commit hash to checkout at that commit where the branch existed.